### PR TITLE
[file-manager] feat: use file id to generate s3 object key

### DIFF
--- a/file-manager/src/application/protocol/files/save-file-storage-service.protocol.ts
+++ b/file-manager/src/application/protocol/files/save-file-storage-service.protocol.ts
@@ -1,4 +1,5 @@
 export interface SaveFileStorageServiceDTO {
+  fileId: string
   content: Buffer
   name: string
   encoding: string

--- a/file-manager/src/application/use-case/file/add-new-file.use-case.ts
+++ b/file-manager/src/application/use-case/file/add-new-file.use-case.ts
@@ -74,6 +74,7 @@ export class AddNewFileUseCase {
       }
 
       await this.saveFileStorageService.save({
+        fileId: file.id,
         name: file.name,
         content: params.content,
         encoding: file.encoding,

--- a/file-manager/src/infra/object-storage/s3.ts
+++ b/file-manager/src/infra/object-storage/s3.ts
@@ -34,7 +34,7 @@ export class S3FileStorage implements SaveFileStorageService, GetFilesUrlsServic
   async save(params: SaveFileStorageServiceDTO): Promise<null> {
     await this.client.send(new CreateBucketCommand({ Bucket: ENVS.S3.BUCKET_NAME }))
 
-    const key = `${params.userId}/${params.name}`
+    const key = `${params.userId}/${params.fileId}`
 
     const command = new PutObjectCommand({
       Bucket: ENVS.S3.BUCKET_NAME,
@@ -57,7 +57,7 @@ export class S3FileStorage implements SaveFileStorageService, GetFilesUrlsServic
     const filesWithUrl = await Promise.all(files.map(async file => {
       const payload: GetObjectCommandInput = {
         Bucket: ENVS.S3.BUCKET_NAME,
-        Key: `${userId}/${file.name}`
+        Key: `${userId}/${file.id}`
       }
 
       const url = await getSignedUrl(

--- a/file-manager/tests/unit/application/use-case/add-new-file.spec.ts
+++ b/file-manager/tests/unit/application/use-case/add-new-file.spec.ts
@@ -74,7 +74,8 @@ describe('Add New File Use Case', () => {
       content: payload.content,
       encoding: payload.encoding,
       type: payload.type,
-      userId: payload.userId
+      userId: payload.userId,
+      fileId: 'any-id'
     })
     expect(saveSpy).toHaveBeenCalledWith({
       id: 'any-id',


### PR DESCRIPTION
### Description
- Use file id instead of file name to generate S3 object's key